### PR TITLE
Add click event to clickOneLayer cb; add noMatchCb to clickOneLayer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,18 +188,27 @@ utils.init = function(map, mapboxgl) {
                 });
                 cb(e);
             });
-        }), clickOneLayer(layers, cb) {
+        }), clickOneLayer(layers, cb, noMatchCb) {
             map.on('click', e => {
+                let match = false;
+          
                 for (const layer of layers) {
                     const features = map.queryRenderedFeatures(e.point, { layers: [ layer ] });
                     if (features[0]) {
                         cb({
+                            event: e,
                             layer,
                             feature: features[0],
-                            features
+                            features,
                         });
+          
+                        match = true;
                         break;
                     }
+                }
+          
+                if (!match && noMatchCb) {
+                    noMatchCb(e);
                 }
             });
         },

--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ utils.init = function(map, mapboxgl) {
                             event: e,
                             layer,
                             feature: features[0],
-                            features,
+                            features
                         });
           
                         match = true;


### PR DESCRIPTION
Two Intentions:

1) Provide the click event to the callback of clickOneLayer, as a property in the object is passed to the callback

2) Provide an option for a callback that triggers if none of the provided layers are clicked.